### PR TITLE
Update juv with janet 1.7.0

### DIFF
--- a/project.janet
+++ b/project.janet
@@ -23,6 +23,7 @@
   :defines (case (os/which)
              :windows {"_WIN32_WINNT" "0x0600"
                        "_GNU_SOURCE" true}
+             :macos {"_GNU_SOURCE" true}
              # default
              {"_POSIX_C_SOURCE" "200112"
               "_GNU_SOURCE" true})

--- a/project.janet
+++ b/project.janet
@@ -97,8 +97,10 @@
 
               # macos specific
               ;(if (= (os/which) :macos)
-                ["libuv/src/unix/darwin.c"
+                ["libuv/src/unix/bsd-ifaddrs.c"
+                 "libuv/src/unix/darwin.c"
                  "libuv/src/unix/fsevents.c"
+                 "libuv/src/unix/kqueue.c"
                  "libuv/src/unix/darwin-proctitle.c"
                  "libuv/src/unix/random-getentropy.c"]
                 [])

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -1,7 +1,7 @@
 #include "entry.h"
 #include "stream.h"
 
-static Janet tcp_method_get(void *p, Janet key);
+static int tcp_method_get(void *p, Janet key, Janet *out);
 const JanetAbstractType tcp_type = {
     "uv/tcp",
     NULL,
@@ -153,11 +153,11 @@ static const JanetMethod tcp_methods[] = {
     {NULL, NULL}
 };
 
-static Janet tcp_method_get(void *p, Janet key) {
+static int tcp_method_get(void *p, Janet key, Janet *out) {
     (void) p;
     if (!janet_checktype(key, JANET_KEYWORD))
         janet_panicf("expected keyword, got %v", key);
-    return janet_getmethod(janet_unwrap_keyword(key), tcp_methods);
+    return janet_getmethod(janet_unwrap_keyword(key), tcp_methods, out);
 }
 
 void submod_tcp(JanetTable *env) {

--- a/src/timer.c
+++ b/src/timer.c
@@ -1,6 +1,6 @@
 #include "entry.h"
 
-static Janet timer_method_get(void *p, Janet key);
+static int timer_method_get(void *p, Janet key, Janet *out);
 static const JanetAbstractType timer_type = {
     "uv/timer",
     NULL,
@@ -103,11 +103,11 @@ static const JanetMethod timer_methods[] = {
     {NULL, NULL}
 };
 
-static Janet timer_method_get(void *p, Janet key) {
+static int timer_method_get(void *p, Janet key, Janet *out) {
     (void) p;
     if (!janet_checktype(key, JANET_KEYWORD))
         janet_panicf("expected keyword, got %v", key);
-    return janet_getmethod(janet_unwrap_keyword(key), timer_methods);
+    return janet_getmethod(janet_unwrap_keyword(key), timer_methods, out);
 }
 
 static const JanetReg cfuns[] = {


### PR DESCRIPTION
This PR does two things

1. updates the getmethod calls to the new arity (Janet *out)
2. gets it building on macos catalina

The catalina change may not be necessary, but I couldn't build without it, something about the `rusage` struct not having the necessary fields