### PR TITLE
Add basic support for FS event monitoring

### DIFF
--- a/project.janet
+++ b/project.janet
@@ -40,8 +40,8 @@
               "libuv/src/strscpy.c"
               "libuv/src/threadpool.c"
               "libuv/src/timer.c"
-              "libuv/src/uv-data-getter-setters.c"
               "libuv/src/uv-common.c"
+              "libuv/src/uv-data-getter-setters.c"
               "libuv/src/version.c"
 
               # windows vs. non-windows
@@ -60,7 +60,6 @@
                   "libuv/src/win/handle.c"
                   "libuv/src/win/loop-watcher.c"
                   "libuv/src/win/pipe.c"
-                  "libuv/src/win/thread.c"
                   "libuv/src/win/poll.c"
                   "libuv/src/win/process.c"
                   "libuv/src/win/process-stdio.c"
@@ -68,12 +67,13 @@
                   "libuv/src/win/snprintf.c"
                   "libuv/src/win/stream.c"
                   "libuv/src/win/tcp.c"
+                  "libuv/src/win/thread.c"
                   "libuv/src/win/tty.c"
                   "libuv/src/win/udp.c"
                   "libuv/src/win/util.c"
                   "libuv/src/win/winapi.c"
                   "libuv/src/win/winsock.c"]
-                 
+
                  # not windows (posix)
                  ["libuv/src/unix/async.c"
                   "libuv/src/unix/core.c"
@@ -112,10 +112,9 @@
                   "libuv/src/unix/linux-syscalls.c"
                   "libuv/src/unix/procfs-exepath.c"
                   "libuv/src/unix/random-getrandom.c"
-                  "libuv/src/unix/random-sysctl.c"
-                  "libuv/src/unix/sysinfo-loadavg.c"]
+                  "libuv/src/unix/random-sysctl-linux.c"]
                  [])
-              
+
               # Janet wrappers
               "src/entry.c"
               "src/fs.c"

--- a/project.janet
+++ b/project.janet
@@ -119,6 +119,7 @@
               # Janet wrappers
               "src/entry.c"
               "src/fs.c"
+              "src/fs_event.c"
               "src/handle.c"
               "src/stream.c"
               "src/tcp.c"

--- a/src/entry.c
+++ b/src/entry.c
@@ -38,6 +38,7 @@ JANET_MODULE_ENTRY(JanetTable *env) {
     janet_def(env, "version", janet_cstringv(uv_version_string()),
             "Libuv version string as a semantic version.");
     submod_fs(env);
+    submod_fs_event(env);
     submod_timer(env);
     submod_tcp(env);
     submod_stream(env);

--- a/src/entry.h
+++ b/src/entry.h
@@ -28,6 +28,7 @@ extern int juv_last_error;
 
 /* submodules */
 void submod_fs(JanetTable *env);
+void submod_fs_event(JanetTable *env);
 void submod_timer(JanetTable *env);
 void submod_tcp(JanetTable *env);
 void submod_stream(JanetTable *env);

--- a/src/fs_event.c
+++ b/src/fs_event.c
@@ -29,7 +29,7 @@ static void fs_event_cleanup(uv_fs_event_t *t) {
     if (res < 0) juv_panic(res);
 }
 
-static void juv_fs_event_cb(uv_fs_event_t *handle, const char *filename, int events, int status) {
+static void fs_event_cb(uv_fs_event_t *handle, const char *filename, int events, int status) {
     if (status) {
         juv_panic(status);
     } else {
@@ -65,7 +65,7 @@ static Janet cfun_fs_event_start(int32_t argc, Janet *argv) {
     juv_handle_setcb(handle, 1, cb);
     const char *path = janet_getcstring(argv, 2);
     uint64_t flags = janet_getinteger(argv, 3);
-    int ret = uv_fs_event_start(handle, juv_fs_event_cb, path, flags);
+    int ret = uv_fs_event_start(handle, fs_event_cb, path, flags);
     if (ret < 0) juv_panic(ret);
     return argv[0];
 }

--- a/src/fs_event.c
+++ b/src/fs_event.c
@@ -92,6 +92,7 @@ static Janet cfun_fs_event_getpath(int32_t argc, Janet *argv) {
 static const JanetMethod fs_event_methods[] = {
     {"start", cfun_fs_event_start},
     {"stop", cfun_fs_event_stop},
+    {"getpath", cfun_fs_event_getpath},
     {NULL, NULL}
 };
 

--- a/src/fs_event.c
+++ b/src/fs_event.c
@@ -1,0 +1,92 @@
+#include "entry.h"
+
+static int fs_event_method_get(void *p, Janet key, Janet *out);
+static const JanetAbstractType fs_event_type = {
+    "uv/fs-event",
+    NULL,
+    juv_handle_mark,
+    fs_event_method_get,
+    JANET_ATEND_GET
+};
+
+static Janet cfun_fs_event_new(int32_t argc, Janet *argv) {
+    janet_fixarity(argc, 1);
+    JanetFiber *fiber = janet_getfiber(argv, 0);
+    uv_fs_event_t* handle = (uv_fs_event_t*) juv_makehandle(&fs_event_type, sizeof(*handle));
+    int ret = uv_fs_event_init(uv_default_loop(), handle);
+    if (ret < 0) janet_panic("could not create fs event monitor");
+    Janet val = juv_wrap_handle(handle);
+    janet_gcroot(val);
+    juv_handle_setfiber(handle, 1, fiber);
+    return val;
+}
+
+static void fs_event_cleanup(uv_fs_event_t *t) {
+    int res = uv_fs_event_stop(t);
+    janet_gcunroot(juv_wrap_handle(t));
+    juv_handle_setfiber(t, 1, NULL);
+    if (res < 0) juv_panic(res);
+}
+
+static void juv_fs_event_cb(uv_fs_event_t* handle, const char *filename, int events, int status) {
+    JanetFiber *fiber = juv_handle_fiber(handle, 1);
+    if (fiber == NULL) {
+        fs_event_cleanup(handle);
+        return;
+    }
+    Janet out;
+    JanetSignal sig = janet_continue(fiber, janet_wrap_nil(), &out);
+    if (sig == JANET_SIGNAL_YIELD) {
+        ;
+    } else if (sig == JANET_SIGNAL_OK) {
+        fs_event_cleanup(handle);
+    } else {
+        fs_event_cleanup(handle);
+        juv_toperror(sig, out);
+    }
+}
+
+static Janet cfun_fs_event_start(int32_t argc, Janet *argv) {
+    janet_fixarity(argc, 3);
+    uv_fs_event_t *handle = juv_gethandle(argv, 0, &fs_event_type);
+    if (juv_handle_fiber(handle, 1) == NULL) {
+        janet_panic("fs event monitor has been destroyed, cannot be restarted");
+    }
+    const char *path = janet_getcstring(argv, 1);
+    uint64_t flags = janet_getinteger(argv, 2);
+    int ret = uv_fs_event_start(handle, juv_fs_event_cb, path, flags);
+    if (ret < 0) juv_panic(ret);
+    return argv[0];
+}
+
+static Janet cfun_fs_event_stop(int32_t argc, Janet *argv) {
+    janet_fixarity(argc, 1);
+    uv_fs_event_t *handle = juv_gethandle(argv, 0, &fs_event_type);
+    if (juv_handle_fiber(handle, 1) == NULL) return janet_wrap_nil();
+    fs_event_cleanup(handle);
+    return janet_wrap_nil();
+}
+
+static const JanetMethod fs_event_methods[] = {
+    {"start", cfun_fs_event_start},
+    {"stop", cfun_fs_event_stop},
+    {NULL, NULL}
+};
+
+static int fs_event_method_get(void *p, Janet key, Janet *out) {
+    (void) p;
+    if (!janet_checktype(key, JANET_KEYWORD))
+        janet_panicf("expected keyword, got %v", key);
+    return janet_getmethod(janet_unwrap_keyword(key), fs_event_methods, out);
+}
+
+static const JanetReg cfuns[] = {
+    {"fs-event/new", cfun_fs_event_new, NULL},
+    {"fs-event/start", cfun_fs_event_start, NULL},
+    {"fs-event/stop", cfun_fs_event_stop, NULL},
+    {NULL, NULL, NULL}
+};
+
+void submod_fs_event(JanetTable *env) {
+    janet_cfuns(env, "uv", cfuns);
+}

--- a/src/fs_event.c
+++ b/src/fs_event.c
@@ -78,6 +78,17 @@ static Janet cfun_fs_event_stop(int32_t argc, Janet *argv) {
     return janet_wrap_nil();
 }
 
+static Janet cfun_fs_event_getpath(int32_t argc, Janet *argv) {
+    janet_fixarity(argc, 1);
+    uv_fs_event_t *handle = juv_gethandle(argv, 0, &fs_event_type);
+    char buf[1024];
+    size_t pathlen = 1023;
+    int r = uv_fs_event_getpath(handle, (char *)&buf, &pathlen);
+    if (r) juv_panic(r);
+    JanetString pathname = janet_string((uint8_t *)buf, pathlen);
+    return janet_wrap_string(pathname);
+}
+
 static const JanetMethod fs_event_methods[] = {
     {"start", cfun_fs_event_start},
     {"stop", cfun_fs_event_stop},
@@ -95,6 +106,7 @@ static const JanetReg cfuns[] = {
     {"fs-event/new", cfun_fs_event_new, NULL},
     {"fs-event/start", cfun_fs_event_start, NULL},
     {"fs-event/stop", cfun_fs_event_stop, NULL},
+    {"fs-event/getpath", cfun_fs_event_getpath, NULL},
     {NULL, NULL, NULL}
 };
 

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -154,7 +154,6 @@ static int tcp_method_get(void *p, Janet key, Janet *out) {
     (void) p;
     if (!janet_checktype(key, JANET_KEYWORD))
         janet_panicf("expected keyword, got %v", key);
-    printf("key: %s\n", janet_unwrap_keyword(key));
     return janet_getmethod(janet_unwrap_keyword(key), tcp_methods, out);
 }
 

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -154,6 +154,7 @@ static int tcp_method_get(void *p, Janet key, Janet *out) {
     (void) p;
     if (!janet_checktype(key, JANET_KEYWORD))
         janet_panicf("expected keyword, got %v", key);
+    printf("key: %s\n", janet_unwrap_keyword(key));
     return janet_getmethod(janet_unwrap_keyword(key), tcp_methods, out);
 }
 

--- a/test/fs-event.janet
+++ b/test/fs-event.janet
@@ -24,7 +24,8 @@
                      (print "File " counter " changed: " path)
                      (set counter (+ 1 counter))
                      (thread/send parent (string "Updated file: " path) 0))
-          handle   (uv/fs-event/new (fiber/new (fn [&]) :yi))]
+          fiber    (fiber/new (fn []) :yi)
+          handle   (uv/fs-event/new fiber)]
       (uv/fs-event/start handle callback "tmp" 0)
       (thread/send parent "Monitor started"))))
 

--- a/test/fs-event.janet
+++ b/test/fs-event.janet
@@ -38,7 +38,9 @@
   (thread/exit))
 
 (def monitor-thread (thread/new monitor))
-(print (thread/receive 5))
+(def monitor-start-msg (thread/receive 5))
+(print monitor-start-msg)
+
 (def writer-thread (thread/new writer))
 
 (loop [i :range [0 4]]

--- a/test/fs-event.janet
+++ b/test/fs-event.janet
@@ -27,7 +27,7 @@
           fiber    (fiber/new (fn []) :yi)
           handle   (uv/fs-event/new fiber)]
       (uv/fs-event/start handle callback "tmp" 0)
-      (thread/send parent "Monitor started"))))
+      (thread/send parent (string "Monitoring directory: " (uv/fs-event/getpath handle))))))
 
 (defn writer
   [parent]

--- a/test/fs-event.janet
+++ b/test/fs-event.janet
@@ -1,0 +1,38 @@
+(import build/uv :as uv)
+
+(defn- rimraf
+  [path]
+  (if-let [m (os/stat path :mode)]
+    (if (= m :directory)
+      (do
+        (each subpath (os/dir path) (rimraf (string path "/" subpath)))
+        (os/rmdir path))
+      (os/rm path))))
+
+#
+# FS Event Monitor
+#
+
+(os/mkdir "tmp")
+
+(defn monitor
+  [parent]
+  (uv/enter-loop
+    (let [f (coro (while true
+                    (thread/send parent "Event received")
+                    (yield)))
+          t (uv/fs-event/new f)]
+      (uv/fs-event/start t "tmp" 4))))
+
+(defn writer
+  [parent]
+  (thread/send parent "Writing first file...")
+  (spit "tmp/test.txt" "This is a test."))
+
+(def monitor-thread (thread/new monitor))
+(def writer-thread (thread/new writer))
+
+(print (thread/receive 5))
+(print (thread/receive 5))
+
+(rimraf "tmp")

--- a/test/fs-event.janet
+++ b/test/fs-event.janet
@@ -19,24 +19,34 @@
 (defn monitor
   [parent]
   (uv/enter-loop
+    (var counter 1)
     (let [callback (fn [handle path events]
+                     (print "File " counter " changed: " path)
+                     (set counter (+ 1 counter))
                      (thread/send parent (string "Updated file: " path) 0))
-          handle   (uv/fs-event/new (fiber/new (fn [&])))]
-      (uv/fs-event/start handle callback "tmp" 0))))
+          handle   (uv/fs-event/new (fiber/new (fn [&]) :yi))]
+      (uv/fs-event/start handle callback "tmp" 0)
+      (thread/send parent "Monitor started"))))
 
 (defn writer
   [parent]
   (thread/send parent "Writing first file..." 0)
   (spit "tmp/test.txt" "This is a test.")
   (thread/send parent "Writing second file..." 0)
-  (spit "tmp/test_dir/test.txt" "This is a test."))
+  (spit "tmp/test_dir/test.txt" "This is a test.")
+  (thread/exit))
 
 (def monitor-thread (thread/new monitor))
+(print (thread/receive 5))
 (def writer-thread (thread/new writer))
 
-(print (thread/receive 5))
-(print (thread/receive 5))
-(print (thread/receive 5))
-(print (thread/receive 5))
+(loop [i :range [0 4]]
+  (try
+    (do
+      (def msg1 (string "Receiving message " (+ 1 i)))
+      (print msg1)
+      (def msg2 (string "Message " (+ 1 i) ": " (thread/receive 5)))
+      (print msg2))
+    ([err] (print err))))
 
 (rimraf "tmp")

--- a/test/tcp.janet
+++ b/test/tcp.janet
@@ -5,25 +5,25 @@
 #
 
 # Echo server
-(uv/enter-loop
-  (def server (uv/tcp/new))
-  (:bind server "0.0.0.0" 8120)
-  (:listen server (fn [&]
-                    (print "connected!")
-                    (def client (uv/tcp/new))
-                    (:accept server client)
-                    (:read-start client)
-                    (while true
-                      (def chunk (yield))
-                      (if chunk
-                        (do
-                          (:write stdout chunk)
-                          (yield (:write client "Howdy, pardner!\n"))
-                          (yield (:write client chunk)))
-                        (do
-                          (print "---done!---")
-                          (:read-stop client)
-                          (break)))))))
+# (uv/enter-loop
+#   (def server (uv/tcp/new))
+#   (:bind server "0.0.0.0" 8120)
+#   (:listen server (fn [&]
+#                     (print "connected!")
+#                     (def client (uv/tcp/new))
+#                     (:accept server client)
+#                     (:read-start client)
+#                     (while true
+#                       (def chunk (yield))
+#                       (if chunk
+#                         (do
+#                           (:write stdout chunk)
+#                           (yield (:write client "Howdy, pardner!\n"))
+#                           (yield (:write client chunk)))
+#                         (do
+#                           (print "---done!---")
+#                           (:read-stop client)
+#                           (break)))))))
 
 # Simple stuff
 (uv/enter-loop


### PR DESCRIPTION
This adds basic support for FS event monitoring using the `fs_event` functions in libuv.

It also updates libuv to v1.40.0 and comments out the TCP test (which seems incomplete at the moment).